### PR TITLE
fixed persian to english replace function

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,18 @@ const _allsolar = persian.concat(solar)
 const _lunar2solar = lunar
 const _allevents = _lunar2solar.concat(_allsolar)
 
+function persianToEnglish (number) {
+    return number.replace(/[\u0660-\u0669\u06f0-\u06f9]/g, function (c) {
+        return c.charCodeAt(0) & 0xf;
+    });
+}
+
 function PHoliday(arg1, arg2, arg3, arg4){
     const _self = momentJalaali(arg1, arg2, arg3, arg4)
     _self.events = function(){
         const _todayNumber = _self.jDayOfYear()
         const _todayHijri = momentHijri(_self)
-        const _todayHijriFormatted = _todayHijri.format('iM/iD')
+        const _todayHijriFormatted = persianToEnglish(_todayHijri.format('iM/iD'))
 
         const events = _allevents.filter(function(item){
             return (item.fday && item.fday == _todayHijriFormatted) || (!item.fday && item.day == _todayNumber)


### PR DESCRIPTION
in Hijri dates, moment returns persian format number, I add a function to replace persian number to english number.
in "_allevents" filter function we had a problem with persian and english number